### PR TITLE
add an alternative install method that avoids pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,9 @@ Install via pip::
 Install manually / via APT:
 
     apt-get install python3-paramiko
+
     git clone https://github.com/thcipriani/sshecret/
+
     cp sshecret.py /usr/local/bin/sshecret   
     
 Wherever ssh is accepted

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,12 @@ Install via pip::
 
     pip install --user sshecret
 
+Install manually / via APT:
+
+    apt-get install python3-paramiko
+    git clone https://github.com/thcipriani/sshecret/
+    cp sshecret.py /usr/local/bin/sshecret   
+    
 Wherever ssh is accepted
 ------------------------
 


### PR DESCRIPTION
install python3-paramiko with apt, then just clone the repo and copy sshecret into $PATH